### PR TITLE
[RecorderSample] Fix bugs - Video orientation and crash issue

### DIFF
--- a/Mobile/RecorderSample/RecorderSample/RecorderSample.Tizen.Mobile/MediaPlayer.cs
+++ b/Mobile/RecorderSample/RecorderSample/RecorderSample.Tizen.Mobile/MediaPlayer.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -27,6 +27,8 @@ namespace RecorderSample.Tizen.Mobile
     {
         private readonly Player _player = new Player();
 
+        private MediaView _playerView;
+
         public event EventHandler Stopped;
 
         public MediaPlayer()
@@ -44,6 +46,11 @@ namespace RecorderSample.Tizen.Mobile
         {
             _player.SetSource(new MediaUriSource(path));
 
+            if (_playerView != null)
+            {
+                SetDisplay();
+            }
+
             await _player.PrepareAsync();
         }
 
@@ -56,9 +63,15 @@ namespace RecorderSample.Tizen.Mobile
             Stopped?.Invoke(this, EventArgs.Empty);
         }
 
+        private void SetDisplay()
+        {
+            _player.Display = new Display(_playerView);
+        }
+
         public void SetDisplay(object nativeView)
         {
-            _player.Display = new Display(nativeView as MediaView);
+            _playerView = nativeView as MediaView;
+            SetDisplay();
         }
 
         public int Duration => _player.StreamInfo.GetDuration();

--- a/Mobile/RecorderSample/RecorderSample/RecorderSample.Tizen.Mobile/RecorderController.cs
+++ b/Mobile/RecorderSample/RecorderSample/RecorderSample.Tizen.Mobile/RecorderController.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -31,6 +31,11 @@ namespace RecorderSample.Tizen.Mobile
 
         public void Prepare()
         {
+            if (Recorder is VideoRecorder)
+            {
+                ((VideoRecorder)Recorder).VideoOrientationTag = Rotation.Rotate90;
+            }
+
             Recorder.Prepare();
         }
 

--- a/Mobile/RecorderSample/RecorderSample/RecorderSample/ViewModels/RecordingViewModel.cs
+++ b/Mobile/RecorderSample/RecorderSample/RecorderSample/ViewModels/RecordingViewModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -136,6 +136,7 @@ namespace RecorderSample
             get
             {
                 _saveFileInfo.Refresh();
+
                 if (!_saveFileInfo.Exists)
                 {
                     return null;
@@ -165,9 +166,9 @@ namespace RecorderSample
         public object CameraView
         {
             set
-        {
-                if (value != null)
             {
+                if (value != null)
+                {
                     (Controller as IVideoRecorderController)?.SetDisplay(value);
                 }
             }
@@ -178,7 +179,7 @@ namespace RecorderSample
             set
             {
                 if (value != null)
-        {
+                {
                     MediaPlayer.SetDisplay(value);
                 }
             }


### PR DESCRIPTION
1. Video orientation was not set correctly before recording.
2. Crash was occured when user try to play again without back to previous mainpage.
   (SetDisplay was missing)