### PR TITLE
[PlayerSample] fix blinking issue

### DIFF
--- a/Mobile/PlayerSample/PlayerSample/PlayerSample.Tizen.Mobile/SecurityPort.cs
+++ b/Mobile/PlayerSample/PlayerSample/PlayerSample.Tizen.Mobile/SecurityPort.cs
@@ -27,6 +27,7 @@ namespace PlayerSample.Tizen.Mobile
         /// <summary>
         /// Used to check privilege.
         /// </summary>
+        /// <param name="privilege"></param>
         public void CheckPrivilege(string privilege)
         {
             CheckResult result = PrivacyPrivilegeManager.CheckPermission(privilege);

--- a/Mobile/PlayerSample/PlayerSample/PlayerSample/ViewModels/PlayPageViewModel.cs
+++ b/Mobile/PlayerSample/PlayerSample/PlayerSample/ViewModels/PlayPageViewModel.cs
@@ -70,10 +70,9 @@ namespace PlayerSample
                     break;
             }
 
-            ErrorText = null;
-
             OnPropertyChanged(nameof(PositionText));
             OnPropertyChanged(nameof(IsStarted));
+            OnPropertyChanged(nameof(IsReady));
             OnPropertyChanged(nameof(PlayText));
             OnPropertyChanged(nameof(PauseText));
         }
@@ -172,6 +171,8 @@ namespace PlayerSample
 
         public bool IsStarted => PlayerState == MediaPlayerState.Playing ||
             PlayerState == MediaPlayerState.Paused;
+
+        public bool IsReady => IsStarted || PlayerState == MediaPlayerState.Ready;
 
         private bool _isSeekable;
         public bool IsSeekable

--- a/Mobile/PlayerSample/PlayerSample/PlayerSample/Views/PlayPage.xaml
+++ b/Mobile/PlayerSample/PlayerSample/PlayerSample/Views/PlayPage.xaml
@@ -31,9 +31,7 @@
                                 ConverterParameter={x:Static local:MediaPlayerState.Idle}}" />
 
                 <Button Text="{Binding PauseText}" Command="{Binding PauseCommand}"
-                        IsEnabled="{Binding IsStarted}"
-                        IsVisible="{Binding PlayerState, Converter={StaticResource stateToBoolInverter},
-                                ConverterParameter={x:Static local:MediaPlayerState.Idle}}"/>
+                        IsVisible="{Binding IsStarted}"/>
 
                 <Button Text="&lt;&lt;" Command="{Binding SeekBackwardCommand}"
                         IsEnabled="{Binding IsSeekable}"
@@ -51,8 +49,8 @@
                                 ConverterParameter={x:Static local:MediaPlayerState.Preparing}}"/>
 
                 <Button Text="StreamInfo" Command="{Binding StreamInfoCommand}"
-                        IsVisible="{Binding PlayerState, Converter={StaticResource stateToBoolInverter},
-                                ConverterParameter={x:Static local:MediaPlayerState.Idle}}"/>
+                        IsVisible="true"
+                        IsEnabled="{Binding IsReady}}"/>
             </StackLayout>
 
             <AbsoluteLayout VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">


### PR DESCRIPTION
[Issue] http://suprem.sec.samsung.net/jira/browse/TNEXT-13754

[Cause]
1. whenever error occurs, both callback and return value come. and ErrorText is changed.
2. visibility of pause/resume and streaminfo buttons depends on MediaPlayerState.Idle

[Solution]
1. fixed it not to update ErrorText frequently.
2. changed options of IsVisible and IsEnabled
