### PR TITLE
Find all samples on CLI build

### DIFF
--- a/Mobile/build_m.sh
+++ b/Mobile/build_m.sh
@@ -2,7 +2,7 @@
 
 rm build_result_m.txt
 
-for file in **/*.sln; do
+for file in $(find ./ -name "*.sln"); do
     echo "$file"
     sudo dotnet clean "./$file"
     sudo dotnet clean "---------------------------------------------------------------------------------------" >> build_result_m.txt

--- a/TV/build_tv.sh
+++ b/TV/build_tv.sh
@@ -2,7 +2,7 @@
 
 rm build_result_tv.txt
 
-for file in **/*.sln; do
+for file in $(find ./ -name "*.sln"); do
     echo "$file"
     sudo dotnet clean "./$file"
     sudo dotnet clean "---------------------------------------------------------------------------------------" >> build_result_tv.txt

--- a/Wearable/build_w.sh
+++ b/Wearable/build_w.sh
@@ -2,7 +2,7 @@
 
 rm build_result_w.txt
 
-for file in **/*.sln; do
+for file in $(find ./ -name "*.sln"); do
     echo "$file"
     sudo dotnet clean "./$file"
     sudo dotnet clean "---------------------------------------------------------------------------------------" >> build_result_w.txt


### PR DESCRIPTION
Expression `**/*.sln` does not look into subdirectories, `TV/MapView/src/` for example. It leads to ignore some samples during CLI build. `find` utility use fixes the problem.

Signed-off-by: Timur <t-mustafin@partner.samsung.com>