### PR TITLE
Update Gallery app in TV profile

### DIFF
--- a/TV/Gallery/Gallery/Gallery.TizenTV/Gallery.TizenTV.csproj
+++ b/TV/Gallery/Gallery/Gallery.TizenTV/Gallery.TizenTV.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <!-- Property Group for Tizen40 Project -->
   <PropertyGroup>

--- a/TV/Gallery/Gallery/Gallery/Controls/Panel.cs
+++ b/TV/Gallery/Gallery/Gallery/Controls/Panel.cs
@@ -30,9 +30,9 @@ namespace Gallery.Controls
 
         public bool AllowedFocused { get; set; } = true;
 
-        public int ItemsWidth { get; set; } = 150;
+        public int ItemsWidth { get; set; } = 750;
 
-        public int ItemsHeight { get; set; } = 150;
+        public int ItemsHeight { get; set; } = 750;
 
         public double ScrollX => _scrollView.ScrollX;
 

--- a/TV/Gallery/Gallery/Gallery/Gallery.csproj
+++ b/TV/Gallery/Gallery/Gallery/Gallery.csproj
@@ -6,7 +6,7 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Upgraded Xamarin Forms version to remove build warning (4.x => 5.0)
- Upgraded Tizen.Sdk version (1.0.9=>1.1.6)
- Adjusted image width and height to see image sliding