### PR TITLE
Update codes and project settings to remove build warning - deprecation

### DIFF
--- a/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI.TizenTV/MusicPlayerUI.TizenTV.csproj
+++ b/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI.TizenTV/MusicPlayerUI.TizenTV.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
 </Project>

--- a/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MainPage.xaml
+++ b/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MainPage.xaml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<MasterDetailPage
+<FlyoutPage
     x:Class="MusicPlayerUI.MainPage"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:local="clr-namespace:MusicPlayerUI.Page;assembly=MusicPlayerUI"
     Title="Music Player">
 
-    <MasterDetailPage.Master>
+    <FlyoutPage.Flyout>
         <local:MenuPage />
-    </MasterDetailPage.Master>
+    </FlyoutPage.Flyout>
 
-    <MasterDetailPage.Detail>
+    <FlyoutPage.Detail>
         <local:DetailPage />
-    </MasterDetailPage.Detail>
-</MasterDetailPage>
+    </FlyoutPage.Detail>
+</FlyoutPage>

--- a/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MainPage.xaml.cs
+++ b/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MainPage.xaml.cs
@@ -5,7 +5,7 @@ namespace MusicPlayerUI
     /// <summary>
     /// The main page of the application
     /// </summary>
-    public partial class MainPage : MasterDetailPage
+    public partial class MainPage : FlyoutPage
     {
         /// <summary>
         /// Constructor

--- a/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI.csproj
+++ b/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI.csproj
@@ -6,7 +6,7 @@
 
   <!-- Include Nuget Package for Xamarin building -->
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.356" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
 </Project>

--- a/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/Page/DetailPage.xaml.cs
+++ b/TV/Xamarin.Forms/MusicPlayerUI/MusicPlayerUI/MusicPlayerUI/Page/DetailPage.xaml.cs
@@ -23,7 +23,7 @@ namespace MusicPlayerUI.Page
 
 		private void OnExcuteToolbarMenu(object sender, System.EventArgs e)
 		{
-			(Parent as MasterDetailPage).IsPresented = !(Parent as MasterDetailPage).IsPresented;
+			(Parent as FlyoutPage).IsPresented = !(Parent as FlyoutPage).IsPresented;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Recommended project version for your tizen project settings:
<Project Sdk="Tizen.NET.Sdk/1.1.6">

How to handle build warning: warning : Xamarin.Forms recommends TargetPlatformMinVersion >= 10.0.14393.0 (current project is -1)
Need to use Xamarin.Forms >= 5.0.0.0

How to handle the deprecation of MasterDetailPage (Renamed to FlyoutPage)?
https://docs.microsoft.com/en-us/xamarin/xamarin-forms/release-notes/5.0/5.0.0-pre3#masterdetailpage-renamed
Simple solution: Rename it like below
MasterDetailPage => FlyoutPage in your cs or xaml file
MasterDetailPage.Master => FlyoutPage.Flyout in your xaml file