### PR TITLE
Use the latest Tizen.NET.Sdk in all NUI projects

### DIFF
--- a/Mobile/NUI/CheckBox/NUI_CheckBox/NUI_CheckBox.csproj
+++ b/Mobile/NUI/CheckBox/NUI_CheckBox/NUI_CheckBox.csproj
@@ -1,24 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="8.0.0.15625">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.1.2" />
-  </ItemGroup>
 </Project>
 

--- a/Mobile/NUI/CustomLayout/NUI_CustomLayout/NUI_CustomLayout.csproj
+++ b/Mobile/NUI/CustomLayout/NUI_CustomLayout/NUI_CustomLayout.csproj
@@ -1,21 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
-
 </Project>
-

--- a/Mobile/NUI/CustomView/NUI_CustomView/NUI_CustomView.csproj
+++ b/Mobile/NUI/CustomView/NUI_CustomView/NUI_CustomView.csproj
@@ -1,21 +1,9 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
 
 </Project>
 

--- a/Mobile/NUI/FlexLayout/NUIFlexLayout/NUIFlexLayout.csproj
+++ b/Mobile/NUI/FlexLayout/NUIFlexLayout/NUIFlexLayout.csproj
@@ -1,19 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
 
 </Project>

--- a/Mobile/NUI/GridLayout/NUIGridLayout/NUIGridLayout.csproj
+++ b/Mobile/NUI/GridLayout/NUIGridLayout/NUIGridLayout.csproj
@@ -1,19 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
 
 </Project>

--- a/Mobile/NUI/Layer/NUI_Layer/NUI_Layer.csproj
+++ b/Mobile/NUI/Layer/NUI_Layer/NUI_Layer.csproj
@@ -1,21 +1,9 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-    <Folder Include="res\images\" />
-  </ItemGroup>
 
 </Project>
 

--- a/Mobile/NUI/LinearLayout/NUILinearLayout/NUILinearLayout.csproj
+++ b/Mobile/NUI/LinearLayout/NUILinearLayout/NUILinearLayout.csproj
@@ -1,19 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
 
 </Project>

--- a/Mobile/NUI/NotificationExample/NotificationExample/NotificationExample.csproj
+++ b/Mobile/NUI/NotificationExample/NotificationExample/NotificationExample.csproj
@@ -1,27 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
-    <AssemblyName>NotificationExample</AssemblyName>
-    <RootNamespace>NotificationExample</RootNamespace>	
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="8.0.0.15625">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.1.2" />
-  </ItemGroup>
 
 </Project>
 

--- a/Mobile/NUI/Pagination/NUI_Pagination/NUI_Pagination.csproj
+++ b/Mobile/NUI/Pagination/NUI_Pagination/NUI_Pagination.csproj
@@ -1,24 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="8.0.0.15625">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.1.2" />
-  </ItemGroup>
 </Project>
 

--- a/Mobile/NUI/ScrollableBaseExample/ScrollableBaseExample/ScrollableBaseExample.csproj
+++ b/Mobile/NUI/ScrollableBaseExample/ScrollableBaseExample/ScrollableBaseExample.csproj
@@ -1,30 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
-	<LangVersion>8.0</LangVersion>
-	<TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+	  <LangVersion>8.0</LangVersion>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-    <Folder Include="res\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="8.0.0.15625">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-	<PackageReference Include="Tizen.NET.Sdk" Version="1.1.2" />
-  </ItemGroup>
 
 </Project>
 

--- a/Mobile/NUI/VideoViewSample/VideoViewSample/VideoViewSample.csproj
+++ b/Mobile/NUI/VideoViewSample/VideoViewSample/VideoViewSample.csproj
@@ -1,21 +1,9 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.1.5">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
-      <AssemblyName>VideoViewSample</AssemblyName>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
 
 </Project>
 

--- a/Mobile/NUI/View/NUIView/NUIView.csproj
+++ b/Mobile/NUI/View/NUIView/NUIView.csproj
@@ -1,19 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
 
 </Project>

--- a/Mobile/NUI/Visuals/NUI_Visuals/NUI_Visuals.csproj
+++ b/Mobile/NUI/Visuals/NUI_Visuals/NUI_Visuals.csproj
@@ -1,24 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen80</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="8.0.0.15625">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.1.2" />
-  </ItemGroup>
 </Project>
 

--- a/TV/NUI/ChannelList/ChannelList/ChannelList.csproj
+++ b/TV/NUI/ChannelList/ChannelList/ChannelList.csproj
@@ -1,21 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
-
 </Project>
-

--- a/TV/NUI/FirstScreen/FirstScreen/FirstScreen.csproj
+++ b/TV/NUI/FirstScreen/FirstScreen/FirstScreen.csproj
@@ -1,21 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
-
 </Project>
-

--- a/TV/NUI/MediaHubSample/MediaHubSample/MediaHubSample.csproj
+++ b/TV/NUI/MediaHubSample/MediaHubSample/MediaHubSample.csproj
@@ -1,20 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
 
 </Project>

--- a/TV/NUI/MovieLibrary/MovieLibrary/MovieLibrary.csproj
+++ b/TV/NUI/MovieLibrary/MovieLibrary/MovieLibrary.csproj
@@ -1,20 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\" />
-  </ItemGroup>
-
 </Project>
-

--- a/TV/NUI/VisualSample/VisualSample/VisualSample.csproj
+++ b/TV/NUI/VisualSample/VisualSample/VisualSample.csproj
@@ -1,20 +1,8 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen60</TargetFramework>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>portable</DebugType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>None</DebugType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="lib\"/>
-    <Folder Include="res\"/>
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
context: https://code.sec.samsung.net/jira/browse/TSIX-8968

To fix build break in the latest VS2019, all csproj of NUI projects should be fixed to use the latest Tizen.NET.Sdk. 
