### PR TITLE
VoiceRecorder - change default format to MP4

### DIFF
--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/ApplicationService.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/ApplicationService.cs
@@ -39,7 +39,7 @@ namespace VoiceRecorder.Tizen.Mobile.Service
             }
             catch (Exception)
             {
-                global::Tizen.Log.Error("VoiceRecorder", "Unable to close the application");
+                global::Tizen.Log.Error(Program.LogTag, "Unable to close the application");
             }
         }
 

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/MediaDatabaseService.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/MediaDatabaseService.cs
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 using System;
+using System.Runtime.CompilerServices;
 using Tizen.Content.MediaContent;
 using VoiceRecorder.Model;
 using VoiceRecorder.Tizen.Mobile.Service;
 using Xamarin.Forms;
 
-[assembly: Dependency(typeof(MediaDatabaseService))]
+[assembly: Xamarin.Forms.Dependency(typeof(MediaDatabaseService))]
 
 namespace VoiceRecorder.Tizen.Mobile.Service
 {
@@ -107,8 +108,9 @@ namespace VoiceRecorder.Tizen.Mobile.Service
         /// Invokes "ErrorOccurred" to other application's modules.
         /// </summary>
         /// <param name="errorMessage">Message of a thrown error.</param>
-        private void ErrorHandler(string errorMessage)
+        private void ErrorHandler(string errorMessage, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
         {
+            global::Tizen.Log.Error(Program.LogTag, errorMessage, file, func, line);
             ErrorOccurred?.Invoke(this, errorMessage);
         }
 

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/RecordingFilesReader.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/RecordingFilesReader.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Tizen.Multimedia;
 using VoiceRecorder.Model;
 using VoiceRecorder.Tizen.Mobile.Service;
@@ -155,8 +156,9 @@ namespace VoiceRecorder.Tizen.Mobile.Service
         /// Invokes "ErrorOccurred" to other application's modules.
         /// </summary>
         /// <param name="errorMessage">Message of a thrown error.</param>
-        private void ErrorHandler(string errorMessage)
+        private void ErrorHandler(string errorMessage, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
         {
+            global::Tizen.Log.Error(Program.LogTag, errorMessage, file, func, line);
             ErrorOccurred?.Invoke(this, errorMessage);
         }
 

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoicePlayerService.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoicePlayerService.cs
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 using System;
+using System.Runtime.CompilerServices;
 using Tizen.Multimedia;
 using VoiceRecorder.Model;
 using VoiceRecorder.Tizen.Mobile.Service;
 using Xamarin.Forms;
 
-[assembly: Dependency(typeof(VoicePlayerService))]
+[assembly: Xamarin.Forms.Dependency(typeof(VoicePlayerService))]
 
 namespace VoiceRecorder.Tizen.Mobile.Service
 {
@@ -224,8 +225,9 @@ namespace VoiceRecorder.Tizen.Mobile.Service
         /// Invokes "ErrorOccurred" to other application's modules.
         /// </summary>
         /// <param name="errorMessage">Message of a thrown error.</param>
-        private void ErrorHandler(string errorMessage)
+        private void ErrorHandler(string errorMessage, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
         {
+            global::Tizen.Log.Error(Program.LogTag, errorMessage, file, func, line);
             ErrorOccurred?.Invoke(this, errorMessage);
         }
 

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoiceRecorderService.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoiceRecorderService.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using Tizen.Multimedia;
 using Tizen.Security;
 using VoiceRecorder.Model;
@@ -24,7 +25,7 @@ using VoiceRecorder.Tizen.Mobile.Service;
 using VoiceRecorder.Utils;
 using Xamarin.Forms;
 
-[assembly: Dependency(typeof(VoiceRecorderService))]
+[assembly: Xamarin.Forms.Dependency(typeof(VoiceRecorderService))]
 
 namespace VoiceRecorder.Tizen.Mobile.Service
 {
@@ -378,8 +379,9 @@ namespace VoiceRecorder.Tizen.Mobile.Service
         /// Invokes "ErrorOccurred" to other application's modules.
         /// </summary>
         /// <param name="errorMessage">Message of a thrown error.</param>
-        private void ErrorHandler(string errorMessage)
+        private void ErrorHandler(string errorMessage, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
         {
+            global::Tizen.Log.Error(Program.LogTag, errorMessage, file, func, line);
             ErrorOccurred?.Invoke(this, errorMessage);
         }
 

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoiceRecorderService.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/Service/VoiceRecorderService.cs
@@ -150,12 +150,15 @@ namespace VoiceRecorder.Tizen.Mobile.Service
         /// </summary>
         public void Init()
         {
+            var bitrateType = AudioBitRateType.Medium;
+            var fileFormat = FileFormatType.MP4;
             try
             {
                 Directory.CreateDirectory(PATH_TO_RECORDINGS);
-                _recorder = new AudioRecorder(RecorderAudioCodec.Pcm, RecorderFileFormat.Wav)
+                var formatCodec = FILE_FORMATS_DICTIONARY[fileFormat];
+                _recorder = new AudioRecorder(formatCodec.Item2, formatCodec.Item1)
                 {
-                    AudioBitRate = RECORDING_QUALITY_DICTIONARY[AudioBitRateType.High],
+                    AudioBitRate = RECORDING_QUALITY_DICTIONARY[bitrateType],
                     AudioChannels = (int)AudioChannelType.Stereo
                 };
                 _recorder.Prepare();
@@ -166,8 +169,8 @@ namespace VoiceRecorder.Tizen.Mobile.Service
                 return;
             }
 
-            FileFormatUpdated?.Invoke(this, FileFormatType.WAV);
-            RecordingQualityUpdated?.Invoke(this, AudioBitRateType.High);
+            FileFormatUpdated?.Invoke(this, fileFormat);
+            RecordingQualityUpdated?.Invoke(this, bitrateType);
         }
 
         /// <summary>

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/VoiceRecorder.Tizen.Mobile.cs
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/VoiceRecorder.Tizen.Mobile.cs
@@ -25,6 +25,11 @@ namespace VoiceRecorder.Tizen.Mobile
         #region
 
         /// <summary>
+        /// Tag used for Tizen.Log entries.
+        /// </summary>
+        internal static String LogTag = "VoiceRecorder";
+
+        /// <summary>
         /// Stores <see cref="PrivilegeManager" /> class instance.
         /// </summary>
         private PrivilegeManager _privilegeManager = PrivilegeManager.Instance;

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/VoiceRecorder.Tizen.Mobile.csproj
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder.Tizen.Mobile/VoiceRecorder.Tizen.Mobile.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Tizen.NET.Sdk/1.0.9">
+﻿<Project Sdk="Tizen.NET.Sdk/1.1.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.396" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder/VoiceRecorder.csproj
+++ b/Mobile/Xamarin.Forms/VoiceRecorder/src/VoiceRecorder/VoiceRecorder/VoiceRecorder.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.396" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <!-- Include Nuget Package for Xamarin building -->


### PR DESCRIPTION
As you can see in the list of commits, the PR includes updating Xamarin.Forms to 5.0, Tizen.Log.Error() logging, and a small change in the app.
In standard 6.0 mobile emulator there is an issue with MetadataExtractor for WAV files. It causes an error popup when the recording is finished and when you start application while there already are some wav recordings. The playback works, but the app cant find the duration of the recording. I've decided to change the app and record MP4 by default. As long as the user sticks to the default everything is working correctly.
I've tried it on 5.5 emulator - the duration is determined correctly, but the playback fails. 