### PR TITLE
Adding contact privilege for subscribing calendar DB changes

### DIFF
--- a/Mobile/Xamarin.Forms/SampleSync/SampleSync/SampleSync.Tizen.Mobile/Port/SampleSyncPort.cs
+++ b/Mobile/Xamarin.Forms/SampleSync/SampleSync/SampleSync.Tizen.Mobile/Port/SampleSyncPort.cs
@@ -431,6 +431,7 @@ namespace SampleSync.Tizen.Port
                 case CheckResult.Ask:
                     // User permission request required
                     AskPrivacyPrivilege("http://tizen.org/privilege/calendar.read");
+		    PrivacyPrivilegeManager.RequestPermission("http://tizen.org/privilege/contact.read");
                     break;
                 default:
                     break;


### PR DESCRIPTION
Native Sync Manager requires  contact.read permission along with calendar.read  while subscribing calendar db changes.
This change is w.r.t https://code.sec.samsung.net/jira/browse/SAD-834