### PR TITLE
[NUI][VideoViewSample] Make Forward more big step

### DIFF
--- a/Mobile/NUI/VideoViewSample/VideoViewSample/VideoViewSample.cs
+++ b/Mobile/NUI/VideoViewSample/VideoViewSample/VideoViewSample.cs
@@ -159,10 +159,10 @@ namespace VideoViewSample
                     player.Stop();
                     break;
                 case "forward":
-                    player.Forward(2000); // +2 sec
+                    player.Forward(2500); // +2.5 sec
                     break;
                 case "backward":
-                    player.Backward(2000); // -2 sec
+                    player.Backward(2500); // -2.5 sec
                     break;
             }
         }


### PR DESCRIPTION
Current video sample have too long sampling times.
To make it works well, we need to set forward/backward time more than 2.5 seconds.

Signed-off-by: pichulia <eunkiki.hong@samsung.com>