### PR TITLE
[NUI][CheckBox] Replace ItemAlignment to LinearLayout.HorizontalAlignment

### DIFF
--- a/Mobile/NUI/CheckBox/NUI_CheckBox/NUI_CheckBox.cs
+++ b/Mobile/NUI/CheckBox/NUI_CheckBox/NUI_CheckBox.cs
@@ -116,7 +116,7 @@ namespace NUI_CheckBox
             // Create with properties
             CheckBoxExample = new CheckBox();
             CheckBoxExample.Size = CheckBoxSize;
-            CheckBoxExample.ItemAlignment = LinearLayout.Alignment.Center;
+            (CheckBoxExample.Layout as LinearLayout).HorizontalAlignment = HorizontalAlignment.Center;
             CheckBoxExample.ParentOrigin = ParentOrigin.Center;
             CheckBoxExample.PositionUsesPivotPoint = true;
             CheckBoxExample.PivotPoint = PivotPoint.Center;


### PR DESCRIPTION
Since Button.ItemAlignment uses deprecated LinearLayout.Alignment, it
causes warning.

To resolve the warning, Button.ItemAlignment is replaced to
LinearLayout.HorizontalAlignment.