### PR TITLE
Remove deprecated Tizen.NUI.UIComponents reference

### DIFF
--- a/TV/NUI/ChannelList/ChannelList/src/sample/ListData.cs
+++ b/TV/NUI/ChannelList/ChannelList/src/sample/ListData.cs
@@ -17,7 +17,6 @@
 using System;
 using Tizen.NUI;
 
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
 using ChannelList;

--- a/TV/NUI/FirstScreen/FirstScreen/src/MenuScreen.cs
+++ b/TV/NUI/FirstScreen/FirstScreen/src/MenuScreen.cs
@@ -16,7 +16,6 @@
  */
 
 using Tizen.NUI;
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 using System;
 using System.Runtime.InteropServices;

--- a/TV/NUI/FirstScreen/FirstScreen/src/ScrollMenu.cs
+++ b/TV/NUI/FirstScreen/FirstScreen/src/ScrollMenu.cs
@@ -17,7 +17,6 @@
 
 using Tizen.NUI;
 using Tizen.NUI.Constants;
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 using System;
 using System.Runtime.InteropServices;

--- a/TV/NUI/FirstScreen/FirstScreen/src/SourceMenu.cs
+++ b/TV/NUI/FirstScreen/FirstScreen/src/SourceMenu.cs
@@ -16,7 +16,6 @@
  */
 
 using Tizen.NUI;
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 using System;
 using System.Runtime.InteropServices;

--- a/TV/NUI/FirstScreen/FirstScreen/src/SystemMenu.cs
+++ b/TV/NUI/FirstScreen/FirstScreen/src/SystemMenu.cs
@@ -16,7 +16,6 @@
  */
 
 using Tizen.NUI;
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 using System;
 using System.Runtime.InteropServices;

--- a/TV/NUI/MediaHubSample/MediaHubSample/src/View/FootView.cs
+++ b/TV/NUI/MediaHubSample/MediaHubSample/src/View/FootView.cs
@@ -18,7 +18,6 @@
 
 using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
-using Tizen.NUI.UIComponents;
 using System;
 using System.Collections.Generic;
 

--- a/TV/NUI/MediaHubSample/MediaHubSample/src/View/HeadView.cs
+++ b/TV/NUI/MediaHubSample/MediaHubSample/src/View/HeadView.cs
@@ -17,7 +17,6 @@
 
 using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
-using Tizen.NUI.UIComponents;
 using System;
 
 namespace Tizen.NUI.MediaHub

--- a/TV/NUI/MediaHubSample/MediaHubSample/src/View/ImageItem.cs
+++ b/TV/NUI/MediaHubSample/MediaHubSample/src/View/ImageItem.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using Tizen.NUI;
-using Tizen.NUI.UIComponents;
 using Tizen.NUI.BaseComponents;
 
 /// <summary>


### PR DESCRIPTION
Fix error CS0234: The type or namespace name 'UIComponents' does not exist in the namespace 'Tizen.NUI' (are you missing an assembly reference?) if build NUI applications for TV in NativeAOT mode